### PR TITLE
fix: roll expired sprint items into the current sprint (#1174)

### DIFF
--- a/.github/scripts/eslint.config.js
+++ b/.github/scripts/eslint.config.js
@@ -1,0 +1,31 @@
+import js from "@eslint/js";
+import n from "eslint-plugin-n";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
+  n.configs["flat/recommended-module"],
+  {
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: { ...globals.node },
+    },
+    rules: {
+      // Internal, unpublished scripts folder: importing devDependencies (eslint,
+      // test tooling) from config/tests does not ship to any consumer.
+      "n/no-unpublished-import": "off",
+      // Enforce the modern Node practices used in these scripts.
+      "n/prefer-node-protocol": "error",
+      "n/prefer-global/process": "error",
+      "prefer-const": "error",
+      "no-var": "error",
+      eqeqeq: ["error", "smart"],
+    },
+  },
+  {
+    // CLI entry point: exiting the process on bad input / missing env is intended.
+    files: ["**/*.local.js"],
+    rules: { "n/no-process-exit": "off" },
+  },
+];

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -6,6 +6,206 @@
     "": {
       "dependencies": {
         "@octokit/graphql": "9.0.3"
+      },
+      "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.6.0",
+        "eslint-plugin-n": "^18.2.1",
+        "globals": "^17.7.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -92,17 +292,888 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.1.tgz",
+      "integrity": "sha512-aO3C9//yq8JIvYOi/T+jPvcZ9hZzpwzbR8esrYpFtgE9vpbyM8kn42AQOtIqYspVmpaSWr8X+nrlQuAJYxXAaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -6,7 +6,9 @@
   },
   "scripts": {
     "test": "node --test sprint-hygiene.test.js ",
-    "lint": "eslint ."
+    "test:local": "node sprint-hygiene.local.js --plan plan.json",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix ."
   },
   "dependencies": {
     "@octokit/graphql": "9.0.3"

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,6 +1,20 @@
 {
   "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "node --test sprint-hygiene.test.js ",
+    "lint": "eslint ."
+  },
   "dependencies": {
     "@octokit/graphql": "9.0.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.6.0",
+    "eslint-plugin-n": "^18.2.1",
+    "globals": "^17.7.0"
   }
 }

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -10,24 +10,17 @@
 // -- Pure helpers (exported for testing) ----------------------------------
 
 /**
- * Add a number of whole days to an ISO date string (YYYY-MM-DD).
+ * A single sprint iteration as returned by the Projects v2 GraphQL API.
  *
- * @param {string} isoDate - ISO date string (YYYY-MM-DD)
- * @param {number} days
- * @returns {string} ISO date string (YYYY-MM-DD)
+ * @typedef {{ id: string, title: string, startDate: string, duration: number }} SprintIteration
  */
-function addDays(isoDate, days) {
-  const date = new Date(`${isoDate}T00:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + days);
-  return date.toISOString().split("T")[0];
-}
 
 /**
  * Pick the next upcoming sprint from a list of active iterations.
  *
- * @param {Array<{id: string, title: string, startDate: string, duration: number}>} iterations
+ * @param {SprintIteration[]} iterations
  * @param {string} today - ISO date string (YYYY-MM-DD)
- * @returns {{id: string, title: string, startDate: string, duration: number} | null}
+ * @returns {SprintIteration | null}
  */
 export function findNextSprint(iterations, today) {
   const upcoming = iterations
@@ -43,14 +36,17 @@ export function findNextSprint(iterations, today) {
  * (start + duration days) is exclusive, so the day a sprint ends already
  * belongs to the following sprint.
  *
- * @param {Array<{id: string, title: string, startDate: string, duration: number}>} iterations
+ * @param {SprintIteration[]} iterations
  * @param {string} today - ISO date string (YYYY-MM-DD)
- * @returns {{id: string, title: string, startDate: string, duration: number} | null}
+ * @returns {SprintIteration | null}
  */
 export function findCurrentSprint(iterations, today) {
-  const current = iterations.find(
-    (i) => i.startDate <= today && today < addDays(i.startDate, i.duration),
-  );
+  const current = iterations.find((i) => {
+    const end = new Date(`${i.startDate}T00:00:00Z`);
+    end.setUTCDate(end.getUTCDate() + i.duration);
+    const endDate = end.toISOString().split("T")[0];
+    return i.startDate <= today && today < endDate;
+  });
 
   return current ?? null;
 }
@@ -680,7 +676,11 @@ async function loadConfigAndRules(github, core, context, { projectNumber, limit 
   );
 
   const today = new Date().toISOString().split("T")[0];
-  const iterations = config.sprintField.configuration.iterations;
+  // The GraphQL API returns camelCase iteration fields (startDate/duration);
+  // cast away the heuristic REST schema type inferred for `configuration`.
+  const iterations = /** @type {SprintIteration[]} */ (
+    config.sprintField.configuration.iterations
+  );
   const nextSprint = findNextSprint(iterations, today);
 
   if (!nextSprint) {

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -32,12 +32,11 @@ export function findNextSprint(iterations, today) {
 
 /**
  * Pick the sprint whose date range contains today, matching the GitHub
- * Projects `@current` qualifier. A sprint runs for `duration` days starting on
- * `startDate`, so today is current while `startDate <= today < startDate +
- * duration`. Since iterations are contiguous, that exclusive upper bound equals
- * the next sprint's start date: on the changeover day the next sprint is already
- * current (the current sprint's real last day, `startDate + duration - 1`, still
- * counts).
+ * Projects `@current` qualifier: `startDate <= today < startDate + duration`.
+ *
+ * Example - sprint starting 2026-06-30, duration 14 (runs 06-30 .. 07-13):
+ *   2026-07-13 -> current (last day of the sprint)
+ *   2026-07-14 -> next    (this is the following sprint's startDate)
  *
  * @param {SprintIteration[]} iterations
  * @param {string} today - ISO date string (YYYY-MM-DD)

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -32,9 +32,12 @@ export function findNextSprint(iterations, today) {
 
 /**
  * Pick the sprint whose date range contains today, matching the GitHub
- * Projects `@current` qualifier. The start date is inclusive and the end date
- * (start + duration days) is exclusive, so the day a sprint ends already
- * belongs to the following sprint.
+ * Projects `@current` qualifier. A sprint runs for `duration` days starting on
+ * `startDate`, so today is current while `startDate <= today < startDate +
+ * duration`. Since iterations are contiguous, that exclusive upper bound equals
+ * the next sprint's start date: on the changeover day the next sprint is already
+ * current (the current sprint's real last day, `startDate + duration - 1`, still
+ * counts).
  *
  * @param {SprintIteration[]} iterations
  * @param {string} today - ISO date string (YYYY-MM-DD)

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -32,21 +32,9 @@
  * @returns {SprintIteration}
  */
 export function parseIteration(raw) {
-  return { ...raw, startDate: new Date(raw.startDate) };
+    return {...raw, startDate: new Date(raw.startDate)};
 }
 
-/**
- * Add whole days to a `Date`, returning a new `Date` (UTC-based, no mutation).
- *
- * @param {Date} date
- * @param {number} days
- * @returns {Date}
- */
-function addDays(date, days) {
-  const result = new Date(date);
-  result.setUTCDate(result.getUTCDate() + days);
-  return result;
-}
 
 /**
  * Pick the next upcoming sprint from a list of active iterations.
@@ -56,12 +44,14 @@ function addDays(date, days) {
  * @returns {SprintIteration | null}
  */
 export function findNextSprint(iterations, today) {
-  const upcoming = iterations
-    .filter((i) => i.startDate > today)
-    .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+    const upcoming = iterations
+        .filter((i) => i.startDate > today)
+        .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
 
-  return upcoming.length > 0 ? upcoming[0] : null;
+    return upcoming.length > 0 ? upcoming[0] : null;
 }
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
  * Pick the sprint whose date range contains today, matching the GitHub
@@ -76,11 +66,11 @@ export function findNextSprint(iterations, today) {
  * @returns {SprintIteration | null}
  */
 export function findCurrentSprint(iterations, today) {
-  const current = iterations.find(
-    (i) => i.startDate <= today && today < addDays(i.startDate, i.duration),
-  );
+    const current = iterations.find(
+        (i) => i.startDate <= today && today.getTime() < i.startDate.getTime() + i.duration * MS_PER_DAY,
+    );
 
-  return current ?? null;
+    return current ?? null;
 }
 
 // -- Constants ------------------------------------------------------------
@@ -96,11 +86,11 @@ export const DEFAULT_ALLOWED_PROJECT_NUMBER = 10;
  * Throws when the requested project number is not explicitly allowed.
  */
 export function assertAllowedProjectNumber(projectNumber, allowedProjectNumber) {
-  if (allowedProjectNumber == null) return;
+    if (allowedProjectNumber == null) return;
 
-  if (Number(projectNumber) !== Number(allowedProjectNumber)) {
-    throw new Error(`Refusing to run sprint hygiene on unexpected project number ${projectNumber} (expected ${allowedProjectNumber})`);
-  }
+    if (Number(projectNumber) !== Number(allowedProjectNumber)) {
+        throw new Error(`Refusing to run sprint hygiene on unexpected project number ${projectNumber} (expected ${allowedProjectNumber})`);
+    }
 }
 
 /**
@@ -108,10 +98,10 @@ export function assertAllowedProjectNumber(projectNumber, allowedProjectNumber) 
  * search qualifiers such as `no:<field-token>`.
  */
 export function projectFieldQueryToken(fieldName) {
-  return String(fieldName)
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "-");
+    return String(fieldName)
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, "-");
 }
 
 /**
@@ -120,8 +110,8 @@ export function projectFieldQueryToken(fieldName) {
  * In Progress, Review, and QA.
  */
 export function isBacklogHygieneStatus(statusName) {
-  const normalized = (statusName ?? "").trim().toLowerCase();
-  return normalized === "" || SPRINT_ASSIGN_STATUSES.some((status) => normalized.includes(status));
+    const normalized = (statusName ?? "").trim().toLowerCase();
+    return normalized === "" || SPRINT_ASSIGN_STATUSES.some((status) => normalized.includes(status));
 }
 
 /**
@@ -129,8 +119,8 @@ export function isBacklogHygieneStatus(statusName) {
  * names with emoji, so this checks for the words rather than exact names.
  */
 export function isTerminalStatus(statusName) {
-  const normalized = (statusName ?? "").trim().toLowerCase();
-  return EXCLUDED_STATUSES.some((status) => normalized.includes(status));
+    const normalized = (statusName ?? "").trim().toLowerCase();
+    return EXCLUDED_STATUSES.some((status) => normalized.includes(status));
 }
 
 /**
@@ -138,7 +128,7 @@ export function isTerminalStatus(statusName) {
  * such as "🛠️ Needs Refinement".
  */
 export function isNeedsRefinementStatus(statusName) {
-  return (statusName ?? "").trim().toLowerCase().includes("needs refinement");
+    return (statusName ?? "").trim().toLowerCase().includes("needs refinement");
 }
 
 // -- GraphQL queries ------------------------------------------------------
@@ -273,15 +263,15 @@ const UPDATE_STATUS_MUTATION = `
  * @returns {{ id: string, name: string }}
  */
 function resolveNeedsRefinementOption(statusField) {
-  const matches = statusField.options.filter((o) =>
-    o.name.includes("Needs Refinement"),
-  );
+    const matches = statusField.options.filter((o) =>
+        o.name.includes("Needs Refinement"),
+    );
 
-  if (matches.length === 0) {
-    throw new Error('Could not find a status option containing "Needs Refinement"');
-  }
+    if (matches.length === 0) {
+        throw new Error('Could not find a status option containing "Needs Refinement"');
+    }
 
-  return matches[0];
+    return matches[0];
 }
 
 /**
@@ -289,35 +279,35 @@ function resolveNeedsRefinementOption(statusField) {
  *
  * @returns {{ projectId: string, sprintField: object, statusField: object, needsRefinementOption: {id: string, name: string}, storyPointsField: object | null }}
  */
-async function fetchProjectConfig(github, core, { org, projectNumber }) {
-  core.info("Fetching project configuration...");
-  const data = await github.graphql(PROJECT_CONFIG_QUERY, {
-    org,
-    number: projectNumber,
-  });
+async function fetchProjectConfig(github, core, {org, projectNumber}) {
+    core.info("Fetching project configuration...");
+    const data = await github.graphql(PROJECT_CONFIG_QUERY, {
+        org,
+        number: projectNumber,
+    });
 
-  const project = data.organization.projectV2;
+    const project = data.organization.projectV2;
 
-  const fields = project.fields.nodes;
+    const fields = project.fields.nodes;
 
-  const statusField = fields.find((f) => f.name === STATUS_FIELD_NAME);
-  const sprintField = fields.find((f) => f.name === SPRINT_FIELD_NAME);
-  const storyPointsField = STORY_POINTS_FIELD_NAMES
-    .map((fieldName) => fields.find((f) => f.name === fieldName))
-    .find(Boolean) ?? null;
+    const statusField = fields.find((f) => f.name === STATUS_FIELD_NAME);
+    const sprintField = fields.find((f) => f.name === SPRINT_FIELD_NAME);
+    const storyPointsField = STORY_POINTS_FIELD_NAMES
+        .map((fieldName) => fields.find((f) => f.name === fieldName))
+        .find(Boolean) ?? null;
 
-  if (!statusField || !sprintField) {
-    throw new Error("Could not find Status or Sprint fields on the project");
-  }
+    if (!statusField || !sprintField) {
+        throw new Error("Could not find Status or Sprint fields on the project");
+    }
 
-  const needsRefinementOption = resolveNeedsRefinementOption(statusField);
+    const needsRefinementOption = resolveNeedsRefinementOption(statusField);
 
-  core.info(`Project ID:         ${project.id}`);
-  core.info(`Sprint field:       ${sprintField.id}`);
-  core.info(`Status match:       ${needsRefinementOption.name} (${needsRefinementOption.id})`);
-  core.info(`Story Points field: ${storyPointsField ? `${storyPointsField.name} (${storyPointsField.id})` : "not found - unestimated item rule will be skipped"}`);
+    core.info(`Project ID:         ${project.id}`);
+    core.info(`Sprint field:       ${sprintField.id}`);
+    core.info(`Status match:       ${needsRefinementOption.name} (${needsRefinementOption.id})`);
+    core.info(`Story Points field: ${storyPointsField ? `${storyPointsField.name} (${storyPointsField.id})` : "not found - unestimated item rule will be skipped"}`);
 
-  return { projectId: project.id, sprintField, statusField, needsRefinementOption, storyPointsField };
+    return {projectId: project.id, sprintField, statusField, needsRefinementOption, storyPointsField};
 }
 
 /**
@@ -329,36 +319,36 @@ async function fetchProjectConfig(github, core, { org, projectNumber }) {
  * @param {{ projectId: string, filter: string }} opts
  * @returns {Promise<{ items: Array<object>, droppedProjectItems: Array<object> }>}
  */
-async function fetchItems(github, core, { projectId, filter }) {
-  core.info(`Filter: ${filter}`);
+async function fetchItems(github, core, {projectId, filter}) {
+    core.info(`Filter: ${filter}`);
 
-  const items = [];
-  const droppedProjectItems = [];
-  let cursor = null;
+    const items = [];
+    const droppedProjectItems = [];
+    let cursor = null;
 
-  do {
-    const page = await github.graphql(ITEMS_QUERY, {
-      projectId,
-      cursor,
-      filter,
-    });
+    do {
+        const page = await github.graphql(ITEMS_QUERY, {
+            projectId,
+            cursor,
+            filter,
+        });
 
-    const { nodes, pageInfo, totalCount } = page.node.items;
-    if (items.length === 0) {
-      core.info(`Matched items (server-side): ${totalCount}`);
-    }
-    for (const item of nodes) {
-      if (item.content?.__typename === "Issue") {
-        items.push(item);
-      } else {
-        droppedProjectItems.push(item);
-      }
-    }
+        const {nodes, pageInfo, totalCount} = page.node.items;
+        if (items.length === 0) {
+            core.info(`Matched items (server-side): ${totalCount}`);
+        }
+        for (const item of nodes) {
+            if (item.content?.__typename === "Issue") {
+                items.push(item);
+            } else {
+                droppedProjectItems.push(item);
+            }
+        }
 
-    cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
-  } while (cursor);
+        cursor = pageInfo.hasNextPage ? pageInfo.endCursor : null;
+    } while (cursor);
 
-  return { items, droppedProjectItems };
+    return {items, droppedProjectItems};
 }
 
 /**
@@ -366,7 +356,7 @@ async function fetchItems(github, core, { projectId, filter }) {
  * project status column.
  */
 function isClosedIssue(item) {
-  return item.content?.state === "CLOSED";
+    return item.content?.state === "CLOSED";
 }
 
 /**
@@ -374,11 +364,11 @@ function isClosedIssue(item) {
  * Done or Closed.
  */
 function isDoneOrClosedStatus(item) {
-  return isTerminalStatus(item.status?.name);
+    return isTerminalStatus(item.status?.name);
 }
 
 function storyPointsValue(item) {
-  return item.storyPointsNumber ?? item.storyPoints;
+    return item.storyPointsNumber ?? item.storyPoints;
 }
 
 /**
@@ -387,66 +377,66 @@ function storyPointsValue(item) {
  * use "Story Points".
  */
 function hasNoStoryPoints(item) {
-  const storyPoints = storyPointsValue(item);
-  return storyPoints == null || storyPoints.number == null;
+    const storyPoints = storyPointsValue(item);
+    return storyPoints == null || storyPoints.number == null;
 }
 
 function rejectionReason(item, checks) {
-  for (const check of checks) {
-    if (!check.predicate(item)) return check.reason;
-  }
-  return null;
+    for (const check of checks) {
+        if (!check.predicate(item)) return check.reason;
+    }
+    return null;
 }
 
 function incrementReason(counts, reason, amount = 1) {
-  counts.set(reason, (counts.get(reason) ?? 0) + amount);
+    counts.set(reason, (counts.get(reason) ?? 0) + amount);
 }
 
 function logRejectionSummary(core, counts) {
-  if (counts.size === 0) return;
+    if (counts.size === 0) return;
 
-  core.info("Not eligible:");
-  for (const [reason, count] of counts) {
-    core.info(`  ${count} ${reason}`);
-  }
+    core.info("Not eligible:");
+    for (const [reason, count] of counts) {
+        core.info(`  ${count} ${reason}`);
+    }
 }
 
 function droppedProjectItemReason(item) {
-  if (item.content?.__typename === "DraftIssue") return "draft issue item";
-  if (item.content?.__typename === "PullRequest") return "pull request item";
-  return "non-issue project item";
+    if (item.content?.__typename === "DraftIssue") return "draft issue item";
+    if (item.content?.__typename === "PullRequest") return "pull request item";
+    return "non-issue project item";
 }
 
 function itemSummary(item) {
-  return {
-    projectItemId: item.id,
-    issueId: item.content?.id ?? null,
-    number: item.content?.number ?? null,
-    title: item.content?.title ?? "unknown",
-    url: item.content?.url ?? null,
-    state: item.content?.state ?? null,
-    status: item.status?.name ?? null,
-    sprint: item.sprint?.title ?? null,
-    storyPoints: storyPointsValue(item)?.number ?? null,
-  };
+    return {
+        projectItemId: item.id,
+        issueId: item.content?.id ?? null,
+        number: item.content?.number ?? null,
+        title: item.content?.title ?? "unknown",
+        url: item.content?.url ?? null,
+        state: item.content?.state ?? null,
+        status: item.status?.name ?? null,
+        sprint: item.sprint?.title ?? null,
+        storyPoints: storyPointsValue(item)?.number ?? null,
+    };
 }
 
 /**
  * Silently attempt to leave a comment on an issue.
  */
-async function tryAddComment(github, core, commentedIssueIds, { action }) {
-  if (!action.item.issueId) return;
-  if (commentedIssueIds.has(action.item.issueId)) return;
+async function tryAddComment(github, core, commentedIssueIds, {action}) {
+    if (!action.item.issueId) return;
+    if (commentedIssueIds.has(action.item.issueId)) return;
 
-  try {
-    await github.graphql(ADD_COMMENT_MUTATION, {
-      subjectId: action.item.issueId,
-      body: action.commentBody,
-    });
-    commentedIssueIds.add(action.item.issueId);
-  } catch (commentErr) {
-    core.warning(`  Comment failed on #${action.item.number}: ${commentErr.message}`);
-  }
+    try {
+        await github.graphql(ADD_COMMENT_MUTATION, {
+            subjectId: action.item.issueId,
+            body: action.commentBody,
+        });
+        commentedIssueIds.add(action.item.issueId);
+    } catch (commentErr) {
+        core.warning(`  Comment failed on #${action.item.number}: ${commentErr.message}`);
+    }
 }
 
 /**
@@ -458,374 +448,378 @@ async function tryAddComment(github, core, commentedIssueIds, { action }) {
  * @returns {Promise<{ processed: number, failed: number }>}
  */
 async function processActions(core, {
-  actions,
-  ruleName,
-  applyAction,
+    actions,
+    ruleName,
+    applyAction,
 }) {
-  if (actions.length === 0) {
-    core.info("Nothing to update.");
-    return { processed: 0, failed: 0 };
-  }
-
-  core.info(`${actions.length} item(s) selected:`);
-
-  let processed = 0;
-  let failed = 0;
-
-  for (const action of actions) {
-    const number = action.item.number ?? "?";
-    const title = action.item.title ?? "unknown";
-    const itemRef = action.item.url ?? `#${number}`;
-
-    core.info(`Selected ${itemRef} - ${title}`);
-    core.info(`  ${action.description}`);
-
-    try {
-      await applyAction(action);
-      processed += 1;
-    } catch (err) {
-      core.warning(`  #${number} failed: ${err.message}`);
-      failed += 1;
+    if (actions.length === 0) {
+        core.info("Nothing to update.");
+        return {processed: 0, failed: 0};
     }
-  }
 
-  core.info(`\n${ruleName} summary: ${processed} processed, ${failed} failed`);
-  return { processed, failed };
+    core.info(`${actions.length} item(s) selected:`);
+
+    let processed = 0;
+    let failed = 0;
+
+    for (const action of actions) {
+        const number = action.item.number ?? "?";
+        const title = action.item.title ?? "unknown";
+        const itemRef = action.item.url ?? `#${number}`;
+
+        core.info(`Selected ${itemRef} - ${title}`);
+        core.info(`  ${action.description}`);
+
+        try {
+            await applyAction(action);
+            processed += 1;
+        } catch (err) {
+            core.warning(`  #${number} failed: ${err.message}`);
+            failed += 1;
+        }
+    }
+
+    core.info(`\n${ruleName} summary: ${processed} processed, ${failed} failed`);
+    return {processed, failed};
 }
 
 // -- Rules ----------------------------------------------------------------
 
-function sprintChange({ projectId, sprintField, targetSprint }) {
-  return {
-    describe: (item) => `Sprint: ${item.sprint?.title ?? "none"} -> ${targetSprint.title}`,
-    mutation: (item) => ({
-      type: "setSprint",
-      projectId,
-      itemId: item.id,
-      fieldId: sprintField.id,
-      iterationId: targetSprint.id,
-    }),
-  };
+function sprintChange({projectId, sprintField, targetSprint}) {
+    return {
+        describe: (item) => `Sprint: ${item.sprint?.title ?? "none"} -> ${targetSprint.title}`,
+        mutation: (item) => ({
+            type: "setSprint",
+            projectId,
+            itemId: item.id,
+            fieldId: sprintField.id,
+            iterationId: targetSprint.id,
+        }),
+    };
 }
 
-function statusChange({ projectId, statusField, option }) {
-  return {
-    describe: (item) => `Status: ${item.status?.name ?? "(none)"} -> ${option.name}`,
-    mutation: (item) => ({
-      type: "setStatus",
-      projectId,
-      itemId: item.id,
-      fieldId: statusField.id,
-      optionId: option.id,
-    }),
-  };
+function statusChange({projectId, statusField, option}) {
+    return {
+        describe: (item) => `Status: ${item.status?.name ?? "(none)"} -> ${option.name}`,
+        mutation: (item) => ({
+            type: "setStatus",
+            projectId,
+            itemId: item.id,
+            fieldId: statusField.id,
+            optionId: option.id,
+        }),
+    };
 }
 
 function quoteProjectFilterValue(value) {
-  return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 async function applyPlannedMutation(github, action) {
-  if (action.mutation.type === "setSprint") {
-    await github.graphql(UPDATE_SPRINT_MUTATION, {
-      projectId: action.mutation.projectId,
-      itemId: action.mutation.itemId,
-      fieldId: action.mutation.fieldId,
-      iterationId: action.mutation.iterationId,
-    });
-    return;
-  }
+    if (action.mutation.type === "setSprint") {
+        await github.graphql(UPDATE_SPRINT_MUTATION, {
+            projectId: action.mutation.projectId,
+            itemId: action.mutation.itemId,
+            fieldId: action.mutation.fieldId,
+            iterationId: action.mutation.iterationId,
+        });
+        return;
+    }
 
-  if (action.mutation.type === "setStatus") {
-    await github.graphql(UPDATE_STATUS_MUTATION, {
-      projectId: action.mutation.projectId,
-      itemId: action.mutation.itemId,
-      fieldId: action.mutation.fieldId,
-      optionId: action.mutation.optionId,
-    });
-    return;
-  }
+    if (action.mutation.type === "setStatus") {
+        await github.graphql(UPDATE_STATUS_MUTATION, {
+            projectId: action.mutation.projectId,
+            itemId: action.mutation.itemId,
+            fieldId: action.mutation.fieldId,
+            optionId: action.mutation.optionId,
+        });
+        return;
+    }
 
-  throw new Error(`Unsupported planned mutation type: ${action.mutation.type}`);
+    throw new Error(`Unsupported planned mutation type: ${action.mutation.type}`);
 }
 
 function plannedAction(rule, item) {
-  return {
-    rule: rule.name,
-    item: itemSummary(item),
-    description: rule.describeChange(item),
-    commentBody: rule.commentBody(item),
-    mutation: rule.mutation(item),
-  };
+    return {
+        rule: rule.name,
+        item: itemSummary(item),
+        description: rule.describeChange(item),
+        commentBody: rule.commentBody(item),
+        mutation: rule.mutation(item),
+    };
 }
 
 function buildRules(config, sprints) {
-  // Each rule decides where it moves items. Active work rolling off an expired
-  // sprint belongs in the *current* sprint so it stays on the active board,
-  // while refinement work is planned ahead in the *next* sprint.
-  const moveToCurrentSprint = sprintChange({
-    projectId: config.projectId,
-    sprintField: config.sprintField,
-    targetSprint: sprints.current,
-  });
-  const moveToNextSprint = sprintChange({
-    projectId: config.projectId,
-    sprintField: config.sprintField,
-    targetSprint: sprints.next,
-  });
-  const setNeedsRefinement = statusChange({
-    projectId: config.projectId,
-    statusField: config.statusField,
-    option: config.needsRefinementOption,
-  });
+    // Each rule decides where it moves items. Active work rolling off an expired
+    // sprint belongs in the *current* sprint so it stays on the active board,
+    // while refinement work is planned ahead in the *next* sprint.
+    const moveToCurrentSprint = sprintChange({
+        projectId: config.projectId,
+        sprintField: config.sprintField,
+        targetSprint: sprints.current,
+    });
+    const moveToNextSprint = sprintChange({
+        projectId: config.projectId,
+        sprintField: config.sprintField,
+        targetSprint: sprints.next,
+    });
+    const setNeedsRefinement = statusChange({
+        projectId: config.projectId,
+        statusField: config.statusField,
+        option: config.needsRefinementOption,
+    });
 
-  return [
-    {
-      name: "Roll expired sprint items forward",
-      // Project filter: open issues with any sprint before the current sprint.
-      filter: "is:open -is:draft sprint:<@current",
-      // Item checks: keep all non-terminal items, regardless of active status.
-      // This includes ToDo, Next-UP, In Progress, Review, and QA work whose
-      // sprint is already in the past.
-      checks: [
-        { reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item) },
-        { reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item) },
-      ],
-      describeChange: moveToCurrentSprint.describe,
-      commentBody: (item) =>
-        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.current.title}** because this issue had an expired sprint.`,
-      mutation: moveToCurrentSprint.mutation,
-    },
-    {
-      name: "Mark unestimated items for refinement",
-      // Project filter: only open, unestimated issues with a current or
-      // upcoming sprint. Items without a sprint are ignored by default to avoid
-      // pulling the whole backlog into planning. Already-refinement items are
-      // excluded server-side because they already have the target status.
-      filter: [
-        "is:open",
-        "-is:draft",
-        "sprint:>=@current",
-        `no:${projectFieldQueryToken(config.storyPointsField?.name ?? STORY_POINTS_FIELD_NAMES[0])}`,
-        `-status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
-      ].join(" "),
-      skipReason: config.storyPointsField ? null : "no story points field found on project",
-      // Item checks: only unsized backlog/refinement candidates. This avoids
-      // rewriting active sprint-backlog work such as Next-UP/In Progress/Review.
-      checks: [
-        { reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item) },
-        { reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item) },
-        { reason: "active or in-progress status", predicate: (item) => isBacklogHygieneStatus(item.status?.name) },
-        { reason: "already Needs Refinement", predicate: (item) => !isNeedsRefinementStatus(item.status?.name) },
-        { reason: "has story points", predicate: (item) => hasNoStoryPoints(item) },
-      ],
-      describeChange: setNeedsRefinement.describe,
-      commentBody: () =>
-        `Sprint hygiene: status set to **${config.needsRefinementOption.name}** because this issue has no story points yet.`,
-      mutation: setNeedsRefinement.mutation,
-    },
-    {
-      name: "Move refinement work to planning sprint",
-      // Project filter: open Needs Refinement issues currently assigned to the
-      // active sprint. Next-UP stays in @current because it represents planned
-      // current-sprint backlog.
-      filter: [
-        "is:open",
-        "-is:draft",
-        "sprint:@current",
-        `status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
-      ].join(" "),
-      // Item checks: keep the status check as a defensive fallback in case
-      // Project search semantics change.
-      checks: [
-        { reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item) },
-        { reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item) },
-        { reason: "not Needs Refinement", predicate: (item) => isNeedsRefinementStatus(item.status?.name) },
-      ],
-      describeChange: moveToNextSprint.describe,
-      commentBody: (item) =>
-        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.next.title}** because Needs Refinement items are planned in the next sprint.`,
-      mutation: moveToNextSprint.mutation,
-    },
-  ];
+    return [
+        {
+            name: "Roll expired sprint items forward",
+            // Project filter: open issues with any sprint before the current sprint.
+            filter: "is:open -is:draft sprint:<@current",
+            // Item checks: keep all non-terminal items, regardless of active status.
+            // This includes ToDo, Next-UP, In Progress, Review, and QA work whose
+            // sprint is already in the past.
+            checks: [
+                {reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item)},
+                {reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item)},
+            ],
+            describeChange: moveToCurrentSprint.describe,
+            commentBody: (item) =>
+                `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.current.title}** because this issue had an expired sprint.`,
+            mutation: moveToCurrentSprint.mutation,
+        },
+        {
+            name: "Mark unestimated items for refinement",
+            // Project filter: only open, unestimated issues with a current or
+            // upcoming sprint. Items without a sprint are ignored by default to avoid
+            // pulling the whole backlog into planning. Already-refinement items are
+            // excluded server-side because they already have the target status.
+            filter: [
+                "is:open",
+                "-is:draft",
+                "sprint:>=@current",
+                `no:${projectFieldQueryToken(config.storyPointsField?.name ?? STORY_POINTS_FIELD_NAMES[0])}`,
+                `-status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
+            ].join(" "),
+            skipReason: config.storyPointsField ? null : "no story points field found on project",
+            // Item checks: only unsized backlog/refinement candidates. This avoids
+            // rewriting active sprint-backlog work such as Next-UP/In Progress/Review.
+            checks: [
+                {reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item)},
+                {reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item)},
+                {
+                    reason: "active or in-progress status",
+                    predicate: (item) => isBacklogHygieneStatus(item.status?.name)
+                },
+                {reason: "already Needs Refinement", predicate: (item) => !isNeedsRefinementStatus(item.status?.name)},
+                {reason: "has story points", predicate: (item) => hasNoStoryPoints(item)},
+            ],
+            describeChange: setNeedsRefinement.describe,
+            commentBody: () =>
+                `Sprint hygiene: status set to **${config.needsRefinementOption.name}** because this issue has no story points yet.`,
+            mutation: setNeedsRefinement.mutation,
+        },
+        {
+            name: "Move refinement work to planning sprint",
+            // Project filter: open Needs Refinement issues currently assigned to the
+            // active sprint. Next-UP stays in @current because it represents planned
+            // current-sprint backlog.
+            filter: [
+                "is:open",
+                "-is:draft",
+                "sprint:@current",
+                `status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
+            ].join(" "),
+            // Item checks: keep the status check as a defensive fallback in case
+            // Project search semantics change.
+            checks: [
+                {reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item)},
+                {reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item)},
+                {reason: "not Needs Refinement", predicate: (item) => isNeedsRefinementStatus(item.status?.name)},
+            ],
+            describeChange: moveToNextSprint.describe,
+            commentBody: (item) =>
+                `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.next.title}** because Needs Refinement items are planned in the next sprint.`,
+            mutation: moveToNextSprint.mutation,
+        },
+    ];
 }
 
-async function buildRulePlan(github, core, config, rule, { limit }) {
-  core.info(`\n=== Collect: ${rule.name} ===`);
+async function buildRulePlan(github, core, config, rule, {limit}) {
+    core.info(`\n=== Collect: ${rule.name} ===`);
 
-  if (rule.skipReason) {
-    core.info(`Skipped: ${rule.skipReason}`);
-    return {
-      name: rule.name,
-      filter: rule.filter,
-      skipped: true,
-      skipReason: rule.skipReason,
-      matched: 0,
-      planned: 0,
-      actions: [],
-    };
-  }
-
-  const { items, droppedProjectItems } = await fetchItems(github, core, {
-    projectId: config.projectId,
-    filter: rule.filter,
-  });
-  const rejectionCounts = new Map();
-  for (const item of droppedProjectItems) {
-    incrementReason(rejectionCounts, droppedProjectItemReason(item));
-  }
-
-  const matching = [];
-  for (const item of items) {
-    const reason = rejectionReason(item, rule.checks);
-    if (reason) {
-      incrementReason(rejectionCounts, reason);
-    } else {
-      matching.push(item);
+    if (rule.skipReason) {
+        core.info(`Skipped: ${rule.skipReason}`);
+        return {
+            name: rule.name,
+            filter: rule.filter,
+            skipped: true,
+            skipReason: rule.skipReason,
+            matched: 0,
+            planned: 0,
+            actions: [],
+        };
     }
-  }
-  const eligible = limit === undefined ? matching : matching.slice(0, limit);
 
-  core.info(`Eligible: ${matching.length}`);
-  logRejectionSummary(core, rejectionCounts);
-  if (limit !== undefined && matching.length > eligible.length) {
-    core.info(`Limited to ${eligible.length} item(s) for this run`);
-  }
+    const {items, droppedProjectItems} = await fetchItems(github, core, {
+        projectId: config.projectId,
+        filter: rule.filter,
+    });
+    const rejectionCounts = new Map();
+    for (const item of droppedProjectItems) {
+        incrementReason(rejectionCounts, droppedProjectItemReason(item));
+    }
 
-  return {
-    name: rule.name,
-    filter: rule.filter,
-    skipped: false,
-    matched: matching.length,
-    planned: eligible.length,
-    actions: eligible.map((item) => plannedAction(rule, item)),
-  };
+    const matching = [];
+    for (const item of items) {
+        const reason = rejectionReason(item, rule.checks);
+        if (reason) {
+            incrementReason(rejectionCounts, reason);
+        } else {
+            matching.push(item);
+        }
+    }
+    const eligible = limit === undefined ? matching : matching.slice(0, limit);
+
+    core.info(`Eligible: ${matching.length}`);
+    logRejectionSummary(core, rejectionCounts);
+    if (limit !== undefined && matching.length > eligible.length) {
+        core.info(`Limited to ${eligible.length} item(s) for this run`);
+    }
+
+    return {
+        name: rule.name,
+        filter: rule.filter,
+        skipped: false,
+        matched: matching.length,
+        planned: eligible.length,
+        actions: eligible.map((item) => plannedAction(rule, item)),
+    };
 }
 
-async function loadConfigAndRules(github, core, context, { projectNumber, limit }) {
-  const config = await fetchProjectConfig(
-    github, core, { org: context.repo.owner, projectNumber },
-  );
+async function loadConfigAndRules(github, core, context, {projectNumber, limit}) {
+    const config = await fetchProjectConfig(
+        github, core, {org: context.repo.owner, projectNumber},
+    );
 
-  const today = new Date();
-  // The GraphQL API returns camelCase iteration fields (startDate/duration);
-  // cast away the heuristic REST schema type inferred for `configuration`, then
-  // parse ISO strings into Dates once so the rest of the module works on Dates.
-  const rawIterations = /** @type {RawSprintIteration[]} */ (
-    config.sprintField.configuration.iterations
-  );
-  const iterations = rawIterations.map(parseIteration);
-  const nextSprint = findNextSprint(iterations, today);
+    const today = new Date();
+    // The GraphQL API returns camelCase iteration fields (startDate/duration);
+    // cast away the heuristic REST schema type inferred for `configuration`, then
+    // parse ISO strings into Dates once so the rest of the module works on Dates.
+    const rawIterations = /** @type {RawSprintIteration[]} */ (
+        config.sprintField.configuration.iterations
+    );
+    const iterations = rawIterations.map(parseIteration);
+    const nextSprint = findNextSprint(iterations, today);
 
-  if (!nextSprint) {
-    core.setFailed("Could not determine next sprint");
-    return null;
-  }
-  // Fall back to the next sprint if today falls in a gap between iterations so
-  // expired items still move somewhere sensible.
-  const currentSprint = findCurrentSprint(iterations, today) ?? nextSprint;
-  const sprints = { current: currentSprint, next: nextSprint };
+    if (!nextSprint) {
+        core.setFailed("Could not determine next sprint");
+        return null;
+    }
+    // Fall back to the next sprint if today falls in a gap between iterations so
+    // expired items still move somewhere sensible.
+    const currentSprint = findCurrentSprint(iterations, today) ?? nextSprint;
+    const sprints = {current: currentSprint, next: nextSprint};
 
-  core.info(`Current sprint: ${currentSprint.title} (${currentSprint.id})`);
-  core.info(`Next sprint:    ${nextSprint.title} (${nextSprint.id})`);
+    core.info(`Current sprint: ${currentSprint.title} (${currentSprint.id})`);
+    core.info(`Next sprint:    ${nextSprint.title} (${nextSprint.id})`);
 
-  return {
-    config,
-    sprints,
-    rules: buildRules(config, sprints),
-    metadata: {
-      generatedAt: new Date().toISOString(),
-      projectNumber,
-      projectId: config.projectId,
-      currentSprint: {
-        id: currentSprint.id,
-        title: currentSprint.title,
-        startDate: currentSprint.startDate.toISOString().slice(0, 10),
-        duration: currentSprint.duration,
-      },
-      nextSprint: {
-        id: nextSprint.id,
-        title: nextSprint.title,
-        startDate: nextSprint.startDate.toISOString().slice(0, 10),
-        duration: nextSprint.duration,
-      },
-      limit: limit ?? null,
-    },
-  };
+    return {
+        config,
+        sprints,
+        rules: buildRules(config, sprints),
+        metadata: {
+            generatedAt: new Date().toISOString(),
+            projectNumber,
+            projectId: config.projectId,
+            currentSprint: {
+                id: currentSprint.id,
+                title: currentSprint.title,
+                startDate: currentSprint.startDate.toISOString().slice(0, 10),
+                duration: currentSprint.duration,
+            },
+            nextSprint: {
+                id: nextSprint.id,
+                title: nextSprint.title,
+                startDate: nextSprint.startDate.toISOString().slice(0, 10),
+                duration: nextSprint.duration,
+            },
+            limit: limit ?? null,
+        },
+    };
 }
 
 /**
  * @returns {Promise<object | null>}
  */
-export async function collectSprintHygienePlan({ github, core, context, projectNumber, limit, allowedProjectNumber }) {
-  if (!projectNumber) {
-    core.setFailed("projectNumber is required");
-    return null;
-  }
-  assertAllowedProjectNumber(projectNumber, allowedProjectNumber);
+export async function collectSprintHygienePlan({github, core, context, projectNumber, limit, allowedProjectNumber}) {
+    if (!projectNumber) {
+        core.setFailed("projectNumber is required");
+        return null;
+    }
+    assertAllowedProjectNumber(projectNumber, allowedProjectNumber);
 
-  const loaded = await loadConfigAndRules(github, core, context, { projectNumber, limit });
-  if (!loaded) return null;
+    const loaded = await loadConfigAndRules(github, core, context, {projectNumber, limit});
+    if (!loaded) return null;
 
-  const rules = [];
-  for (const rule of loaded.rules) {
-    rules.push(await buildRulePlan(github, core, loaded.config, rule, { limit }));
-  }
-
-  const totalPlanned = rules.reduce((sum, rule) => sum + rule.planned, 0);
-  core.info("\n========================================");
-  core.info("Sprint hygiene collection complete:");
-  for (const rule of rules) {
-    const skipped = rule.skipped ? `, skipped: ${rule.skipReason}` : "";
-    core.info(`  ${rule.name}: ${rule.planned} planned (${rule.matched} eligible${skipped})`);
-  }
-
-  return {
-    ...loaded.metadata,
-    totalPlanned,
-    rules,
-  };
-}
-
-export async function applySprintHygienePlan({ github, core, plan, dryRun = false }) {
-  const commentedIssueIds = new Set();
-  const results = [];
-  const applyAction = dryRun
-    ? async () => {}
-    : async (action) => {
-        await applyPlannedMutation(github, action);
-        await tryAddComment(github, core, commentedIssueIds, { action });
-      };
-
-  for (const rule of plan?.rules ?? []) {
-    core.info(`\n=== ${rule.name} ===`);
-    if (rule.skipped) {
-      core.info(`Skipped: ${rule.skipReason}`);
-      results.push({ name: rule.name, processed: 0, failed: 0 });
-      continue;
+    const rules = [];
+    for (const rule of loaded.rules) {
+        rules.push(await buildRulePlan(github, core, loaded.config, rule, {limit}));
     }
 
-    results.push({
-      name: rule.name,
-      ...await processActions(core, {
-        actions: rule.actions ?? [],
-        ruleName: rule.name,
-        applyAction,
-      }),
-    });
-  }
+    const totalPlanned = rules.reduce((sum, rule) => sum + rule.planned, 0);
+    core.info("\n========================================");
+    core.info("Sprint hygiene collection complete:");
+    for (const rule of rules) {
+        const skipped = rule.skipped ? `, skipped: ${rule.skipReason}` : "";
+        core.info(`  ${rule.name}: ${rule.planned} planned (${rule.matched} eligible${skipped})`);
+    }
 
-  const totalFailed = results.reduce((sum, result) => sum + result.failed, 0);
+    return {
+        ...loaded.metadata,
+        totalPlanned,
+        rules,
+    };
+}
 
-  core.info("\n========================================");
-  core.info(`Sprint hygiene complete${dryRun ? " (DRY RUN - no changes were made)" : ""}:`);
-  for (const result of results) {
-    core.info(`  ${result.name}: ${result.processed} processed, ${result.failed} failed`);
-  }
+export async function applySprintHygienePlan({github, core, plan, dryRun = false}) {
+    const commentedIssueIds = new Set();
+    const results = [];
+    const applyAction = dryRun
+        ? async () => {
+        }
+        : async (action) => {
+            await applyPlannedMutation(github, action);
+            await tryAddComment(github, core, commentedIssueIds, {action});
+        };
 
-  if (totalFailed > 0) {
-    core.setFailed(`${totalFailed} item(s) failed to update across all rules`);
-  }
+    for (const rule of plan?.rules ?? []) {
+        core.info(`\n=== ${rule.name} ===`);
+        if (rule.skipped) {
+            core.info(`Skipped: ${rule.skipReason}`);
+            results.push({name: rule.name, processed: 0, failed: 0});
+            continue;
+        }
 
-  return results;
+        results.push({
+            name: rule.name,
+            ...await processActions(core, {
+                actions: rule.actions ?? [],
+                ruleName: rule.name,
+                applyAction,
+            }),
+        });
+    }
+
+    const totalFailed = results.reduce((sum, result) => sum + result.failed, 0);
+
+    core.info("\n========================================");
+    core.info(`Sprint hygiene complete${dryRun ? " (DRY RUN - no changes were made)" : ""}:`);
+    for (const result of results) {
+        core.info(`  ${result.name}: ${result.processed} processed, ${result.failed} failed`);
+    }
+
+    if (totalFailed > 0) {
+        core.setFailed(`${totalFailed} item(s) failed to update across all rules`);
+    }
+
+    return results;
 }

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -25,7 +25,7 @@
 export function findNextSprint(iterations, today) {
   const upcoming = iterations
     .filter((i) => i.startDate > today)
-    .sort((a, b) => a.startDate.localeCompare(b.startDate));
+    .sort((a, b) => (a.startDate < b.startDate ? -1 : a.startDate > b.startDate ? 1 : 0));
 
   return upcoming.length > 0 ? upcoming[0] : null;
 }
@@ -43,11 +43,11 @@ export function findNextSprint(iterations, today) {
  * @returns {SprintIteration | null}
  */
 export function findCurrentSprint(iterations, today) {
+  const now = new Date(today).getTime();
   const current = iterations.find((i) => {
-    const end = new Date(`${i.startDate}T00:00:00Z`);
-    end.setUTCDate(end.getUTCDate() + i.duration);
-    const endDate = end.toISOString().split("T")[0];
-    return i.startDate <= today && today < endDate;
+    const start = new Date(i.startDate).getTime();
+    const end = start + i.duration * 86_400_000; // duration in days -> ms
+    return start <= now && now < end;
   });
 
   return current ?? null;

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -10,6 +10,19 @@
 // -- Pure helpers (exported for testing) ----------------------------------
 
 /**
+ * Add a number of whole days to an ISO date string (YYYY-MM-DD).
+ *
+ * @param {string} isoDate - ISO date string (YYYY-MM-DD)
+ * @param {number} days
+ * @returns {string} ISO date string (YYYY-MM-DD)
+ */
+function addDays(isoDate, days) {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().split("T")[0];
+}
+
+/**
  * Pick the next upcoming sprint from a list of active iterations.
  *
  * @param {Array<{id: string, title: string, startDate: string, duration: number}>} iterations
@@ -22,6 +35,24 @@ export function findNextSprint(iterations, today) {
     .sort((a, b) => a.startDate.localeCompare(b.startDate));
 
   return upcoming.length > 0 ? upcoming[0] : null;
+}
+
+/**
+ * Pick the sprint whose date range contains today, matching the GitHub
+ * Projects `@current` qualifier. The start date is inclusive and the end date
+ * (start + duration days) is exclusive, so the day a sprint ends already
+ * belongs to the following sprint.
+ *
+ * @param {Array<{id: string, title: string, startDate: string, duration: number}>} iterations
+ * @param {string} today - ISO date string (YYYY-MM-DD)
+ * @returns {{id: string, title: string, startDate: string, duration: number} | null}
+ */
+export function findCurrentSprint(iterations, today) {
+  const current = iterations.find(
+    (i) => i.startDate <= today && today < addDays(i.startDate, i.duration),
+  );
+
+  return current ?? null;
 }
 
 // -- Constants ------------------------------------------------------------
@@ -500,11 +531,19 @@ function plannedAction(rule, item) {
   };
 }
 
-function buildRules(config, targetSprint) {
-  const setTargetSprint = sprintChange({
+function buildRules(config, sprints) {
+  // Each rule decides where it moves items. Active work rolling off an expired
+  // sprint belongs in the *current* sprint so it stays on the active board,
+  // while refinement work is planned ahead in the *next* sprint.
+  const moveToCurrentSprint = sprintChange({
     projectId: config.projectId,
     sprintField: config.sprintField,
-    targetSprint,
+    targetSprint: sprints.current,
+  });
+  const moveToNextSprint = sprintChange({
+    projectId: config.projectId,
+    sprintField: config.sprintField,
+    targetSprint: sprints.next,
   });
   const setNeedsRefinement = statusChange({
     projectId: config.projectId,
@@ -524,10 +563,10 @@ function buildRules(config, targetSprint) {
         { reason: "closed GitHub issue", predicate: (item) => !isClosedIssue(item) },
         { reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item) },
       ],
-      describeChange: setTargetSprint.describe,
+      describeChange: moveToCurrentSprint.describe,
       commentBody: (item) =>
-        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${targetSprint.title}** because this issue had an expired sprint.`,
-      mutation: setTargetSprint.mutation,
+        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.current.title}** because this issue had an expired sprint.`,
+      mutation: moveToCurrentSprint.mutation,
     },
     {
       name: "Mark unestimated items for refinement",
@@ -575,10 +614,10 @@ function buildRules(config, targetSprint) {
         { reason: "Done/Closed project status", predicate: (item) => !isDoneOrClosedStatus(item) },
         { reason: "not Needs Refinement", predicate: (item) => isNeedsRefinementStatus(item.status?.name) },
       ],
-      describeChange: setTargetSprint.describe,
+      describeChange: moveToNextSprint.describe,
       commentBody: (item) =>
-        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${targetSprint.title}** because Needs Refinement items are planned in the next sprint.`,
-      mutation: setTargetSprint.mutation,
+        `Sprint hygiene: automatically moved from **${item.sprint?.title ?? "none"}** to **${sprints.next.title}** because Needs Refinement items are planned in the next sprint.`,
+      mutation: moveToNextSprint.mutation,
     },
   ];
 }
@@ -641,27 +680,40 @@ async function loadConfigAndRules(github, core, context, { projectNumber, limit 
   );
 
   const today = new Date().toISOString().split("T")[0];
-  const targetSprint = findNextSprint(config.sprintField.configuration.iterations, today);
+  const iterations = config.sprintField.configuration.iterations;
+  const nextSprint = findNextSprint(iterations, today);
 
-  if (!targetSprint) {
+  if (!nextSprint) {
     core.setFailed("Could not determine next sprint");
     return null;
   }
-  core.info(`Next sprint: ${targetSprint.title} (${targetSprint.id})`);
+  // Fall back to the next sprint if today falls in a gap between iterations so
+  // expired items still move somewhere sensible.
+  const currentSprint = findCurrentSprint(iterations, today) ?? nextSprint;
+  const sprints = { current: currentSprint, next: nextSprint };
+
+  core.info(`Current sprint: ${currentSprint.title} (${currentSprint.id})`);
+  core.info(`Next sprint:    ${nextSprint.title} (${nextSprint.id})`);
 
   return {
     config,
-    targetSprint,
-    rules: buildRules(config, targetSprint),
+    sprints,
+    rules: buildRules(config, sprints),
     metadata: {
       generatedAt: new Date().toISOString(),
       projectNumber,
       projectId: config.projectId,
-      targetSprint: {
-        id: targetSprint.id,
-        title: targetSprint.title,
-        startDate: targetSprint.startDate,
-        duration: targetSprint.duration,
+      currentSprint: {
+        id: currentSprint.id,
+        title: currentSprint.title,
+        startDate: currentSprint.startDate,
+        duration: currentSprint.duration,
+      },
+      nextSprint: {
+        id: nextSprint.id,
+        title: nextSprint.title,
+        startDate: nextSprint.startDate,
+        duration: nextSprint.duration,
       },
       limit: limit ?? null,
     },

--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -10,22 +10,55 @@
 // -- Pure helpers (exported for testing) ----------------------------------
 
 /**
- * A single sprint iteration as returned by the Projects v2 GraphQL API.
+ * A sprint iteration as returned by the Projects v2 GraphQL API, where
+ * `startDate` is still an ISO date string (YYYY-MM-DD).
  *
- * @typedef {{ id: string, title: string, startDate: string, duration: number }} SprintIteration
+ * @typedef {{ id: string, title: string, startDate: string, duration: number }} RawSprintIteration
  */
+
+/**
+ * A sprint iteration normalized for internal use: `startDate` is a `Date`
+ * (UTC midnight) so the rest of the module compares and offsets real dates
+ * instead of juggling strings. Convert back to ISO only at the API/output edge.
+ *
+ * @typedef {{ id: string, title: string, startDate: Date, duration: number }} SprintIteration
+ */
+
+/**
+ * Parse a raw GraphQL iteration into the internal Date-based shape. ISO
+ * date-only strings parse as UTC midnight, so sprint boundaries stay in UTC.
+ *
+ * @param {RawSprintIteration} raw
+ * @returns {SprintIteration}
+ */
+export function parseIteration(raw) {
+  return { ...raw, startDate: new Date(raw.startDate) };
+}
+
+/**
+ * Add whole days to a `Date`, returning a new `Date` (UTC-based, no mutation).
+ *
+ * @param {Date} date
+ * @param {number} days
+ * @returns {Date}
+ */
+function addDays(date, days) {
+  const result = new Date(date);
+  result.setUTCDate(result.getUTCDate() + days);
+  return result;
+}
 
 /**
  * Pick the next upcoming sprint from a list of active iterations.
  *
  * @param {SprintIteration[]} iterations
- * @param {string} today - ISO date string (YYYY-MM-DD)
+ * @param {Date} today
  * @returns {SprintIteration | null}
  */
 export function findNextSprint(iterations, today) {
   const upcoming = iterations
     .filter((i) => i.startDate > today)
-    .sort((a, b) => (a.startDate < b.startDate ? -1 : a.startDate > b.startDate ? 1 : 0));
+    .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
 
   return upcoming.length > 0 ? upcoming[0] : null;
 }
@@ -39,16 +72,13 @@ export function findNextSprint(iterations, today) {
  *   2026-07-14 -> next    (this is the following sprint's startDate)
  *
  * @param {SprintIteration[]} iterations
- * @param {string} today - ISO date string (YYYY-MM-DD)
+ * @param {Date} today
  * @returns {SprintIteration | null}
  */
 export function findCurrentSprint(iterations, today) {
-  const now = new Date(today).getTime();
-  const current = iterations.find((i) => {
-    const start = new Date(i.startDate).getTime();
-    const end = start + i.duration * 86_400_000; // duration in days -> ms
-    return start <= now && now < end;
-  });
+  const current = iterations.find(
+    (i) => i.startDate <= today && today < addDays(i.startDate, i.duration),
+  );
 
   return current ?? null;
 }
@@ -677,12 +707,14 @@ async function loadConfigAndRules(github, core, context, { projectNumber, limit 
     github, core, { org: context.repo.owner, projectNumber },
   );
 
-  const today = new Date().toISOString().split("T")[0];
+  const today = new Date();
   // The GraphQL API returns camelCase iteration fields (startDate/duration);
-  // cast away the heuristic REST schema type inferred for `configuration`.
-  const iterations = /** @type {SprintIteration[]} */ (
+  // cast away the heuristic REST schema type inferred for `configuration`, then
+  // parse ISO strings into Dates once so the rest of the module works on Dates.
+  const rawIterations = /** @type {RawSprintIteration[]} */ (
     config.sprintField.configuration.iterations
   );
+  const iterations = rawIterations.map(parseIteration);
   const nextSprint = findNextSprint(iterations, today);
 
   if (!nextSprint) {
@@ -708,13 +740,13 @@ async function loadConfigAndRules(github, core, context, { projectNumber, limit 
       currentSprint: {
         id: currentSprint.id,
         title: currentSprint.title,
-        startDate: currentSprint.startDate,
+        startDate: currentSprint.startDate.toISOString().slice(0, 10),
         duration: currentSprint.duration,
       },
       nextSprint: {
         id: nextSprint.id,
         title: nextSprint.title,
-        startDate: nextSprint.startDate,
+        startDate: nextSprint.startDate.toISOString().slice(0, 10),
         duration: nextSprint.duration,
       },
       limit: limit ?? null,

--- a/.github/scripts/sprint-hygiene.local.js
+++ b/.github/scripts/sprint-hygiene.local.js
@@ -11,21 +11,19 @@
 
 import { graphql } from "@octokit/graphql";
 import { writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
 import { applySprintHygienePlan, collectSprintHygienePlan, DEFAULT_ALLOWED_PROJECT_NUMBER } from "./sprint-hygiene.js";
 
-const args = process.argv.slice(2);
-
-function flag(name) {
-  return args.includes(`--${name}`);
-}
-
-function option(name, fallback) {
-  const idx = args.indexOf(`--${name}`);
-  if (idx === -1 || !args[idx + 1] || args[idx + 1].startsWith("--")) {
-    return fallback;
-  }
-  return args[idx + 1];
-}
+const { values } = parseArgs({
+  options: {
+    apply: { type: "boolean", default: false },
+    limit: { type: "string" },
+    plan: { type: "string" },
+    project: { type: "string", default: "10" },
+    org: { type: "string", default: "open-component-model" },
+    "allowed-project-number": { type: "string", default: String(DEFAULT_ALLOWED_PROJECT_NUMBER) },
+  },
+});
 
 const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
 if (!token) {
@@ -33,18 +31,17 @@ if (!token) {
   process.exit(1);
 }
 
-const org = option("org", "open-component-model");
-const projectNumber = Number(option("project", "10"));
-const allowedProjectNumber = Number(option("allowed-project-number", DEFAULT_ALLOWED_PROJECT_NUMBER));
-const dryRun = !flag("apply"); // dry-run by default, --apply to mutate
+const org = values.org;
+const projectNumber = Number(values.project);
+const allowedProjectNumber = Number(values["allowed-project-number"]);
+const dryRun = !values.apply; // dry-run by default, --apply to mutate
 
-const limitArg = option("limit", undefined);
-const planPath = option("plan", undefined);
+const planPath = values.plan;
 let limit;
-if (limitArg !== undefined) {
-  limit = parseInt(limitArg, 10);
+if (values.limit !== undefined) {
+  limit = Number.parseInt(values.limit, 10);
   if (!(limit > 0)) {
-    console.error(`Error: --limit must be a positive integer, got "${limitArg}"`);
+    console.error(`Error: --limit must be a positive integer, got "${values.limit}"`);
     process.exit(1);
   }
 }

--- a/.github/scripts/sprint-hygiene.test.js
+++ b/.github/scripts/sprint-hygiene.test.js
@@ -2,6 +2,7 @@ import assert from "assert";
 import {
   assertAllowedProjectNumber,
   DEFAULT_ALLOWED_PROJECT_NUMBER,
+  findCurrentSprint,
   findNextSprint,
   isBacklogHygieneStatus,
   isNeedsRefinementStatus,
@@ -57,6 +58,66 @@ console.log("Testing findNextSprint...");
 }
 
 console.log("  findNextSprint: all passed");
+
+// ----------------------------------------------------------
+// findCurrentSprint tests
+// ----------------------------------------------------------
+console.log("Testing findCurrentSprint...");
+
+{
+  const iterations = [
+    { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
+    { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
+    { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
+  ];
+
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-04-25").id,
+    "s2",
+    "should pick the sprint whose range contains today",
+  );
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-04-21").id,
+    "s2",
+    "start date is inclusive",
+  );
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-05-04").id,
+    "s2",
+    "last day of the range still belongs to the sprint",
+  );
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-05-05").id,
+    "s3",
+    "end date is exclusive - the next sprint's start day rolls over",
+  );
+}
+
+// Returns null when today is before all iterations
+{
+  const iterations = [
+    { id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 },
+  ];
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-04-25"),
+    null,
+    "should return null when today is before any sprint",
+  );
+}
+
+// Returns null when today is after all iterations (gap with no active sprint)
+{
+  const iterations = [
+    { id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 },
+  ];
+  assert.strictEqual(
+    findCurrentSprint(iterations, "2026-04-25"),
+    null,
+    "should return null when no sprint range contains today",
+  );
+}
+
+console.log("  findCurrentSprint: all passed");
 
 // ----------------------------------------------------------
 // isBacklogHygieneStatus tests

--- a/.github/scripts/sprint-hygiene.test.js
+++ b/.github/scripts/sprint-hygiene.test.js
@@ -1,4 +1,5 @@
-import assert from "assert";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
 import {
   assertAllowedProjectNumber,
   DEFAULT_ALLOWED_PROJECT_NUMBER,
@@ -10,193 +11,119 @@ import {
   projectFieldQueryToken,
 } from "./sprint-hygiene.js";
 
-// ----------------------------------------------------------
-// findNextSprint tests
-// ----------------------------------------------------------
-console.log("Testing findNextSprint...");
+describe("findNextSprint", () => {
+  test("returns the next sprint after the current sprint", () => {
+    const iterations = [
+      { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
+      { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
+      { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
+    ];
+    assert.equal(findNextSprint(iterations, "2026-04-25").id, "s3");
+  });
 
-// Returns the next sprint after the current sprint
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
-    { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
-    { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
-  ];
-  const result = findNextSprint(iterations, "2026-04-25");
-  assert.strictEqual(result.id, "s3", "should pick Sprint 3 as the next sprint");
-}
+  test("returns the sprint after today's starting sprint", () => {
+    const iterations = [
+      { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
+      { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
+      { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
+    ];
+    assert.equal(findNextSprint(iterations, "2026-04-21").id, "s3");
+  });
 
-// Returns the sprint after today's starting sprint
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
-    { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
-    { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
-  ];
-  const result = findNextSprint(iterations, "2026-04-21");
-  assert.strictEqual(result.id, "s3", "should pick the sprint after the one starting today");
-}
+  test("falls back to nearest upcoming sprint when today is before all iterations", () => {
+    const iterations = [
+      { id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 },
+      { id: "s2", title: "Sprint 2", startDate: "2026-05-15", duration: 14 },
+    ];
+    assert.equal(findNextSprint(iterations, "2026-04-25").id, "s1");
+  });
 
-// Falls back to nearest upcoming sprint when today is before all iterations
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 },
-    { id: "s2", title: "Sprint 2", startDate: "2026-05-15", duration: 14 },
-  ];
-  const result = findNextSprint(iterations, "2026-04-25");
-  assert.strictEqual(result.id, "s1", "should pick the nearest upcoming sprint");
-}
+  test("returns null when no upcoming sprint exists", () => {
+    const iterations = [
+      { id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 },
+      { id: "s2", title: "Sprint 2", startDate: "2026-03-15", duration: 14 },
+    ];
+    assert.equal(findNextSprint(iterations, "2026-04-25"), null);
+  });
+});
 
-// Returns null when no upcoming sprint exists
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 },
-    { id: "s2", title: "Sprint 2", startDate: "2026-03-15", duration: 14 },
-  ];
-  const result = findNextSprint(iterations, "2026-04-25");
-  assert.strictEqual(result, null, "should return null when no upcoming sprint exists");
-}
-
-console.log("  findNextSprint: all passed");
-
-// ----------------------------------------------------------
-// findCurrentSprint tests
-// ----------------------------------------------------------
-console.log("Testing findCurrentSprint...");
-
-{
+describe("findCurrentSprint", () => {
   const iterations = [
     { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
     { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
     { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
   ];
 
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-04-25").id,
-    "s2",
-    "should pick the sprint whose range contains today",
-  );
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-04-21").id,
-    "s2",
-    "start date is inclusive",
-  );
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-05-04").id,
-    "s2",
-    "last day of the range still belongs to the sprint",
-  );
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-05-05").id,
-    "s3",
-    "end date is exclusive - the next sprint's start day rolls over",
-  );
-}
+  test("picks the sprint whose range contains today", () => {
+    assert.equal(findCurrentSprint(iterations, "2026-04-25").id, "s2");
+  });
 
-// Returns null when today is before all iterations
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 },
-  ];
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-04-25"),
-    null,
-    "should return null when today is before any sprint",
-  );
-}
+  test("start date is inclusive", () => {
+    assert.equal(findCurrentSprint(iterations, "2026-04-21").id, "s2");
+  });
 
-// Returns null when today is after all iterations (gap with no active sprint)
-{
-  const iterations = [
-    { id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 },
-  ];
-  assert.strictEqual(
-    findCurrentSprint(iterations, "2026-04-25"),
-    null,
-    "should return null when no sprint range contains today",
-  );
-}
+  test("last day of the range still belongs to the sprint", () => {
+    assert.equal(findCurrentSprint(iterations, "2026-05-04").id, "s2");
+  });
 
-console.log("  findCurrentSprint: all passed");
+  test("end date is exclusive - the next sprint's start day rolls over", () => {
+    assert.equal(findCurrentSprint(iterations, "2026-05-05").id, "s3");
+  });
 
-// ----------------------------------------------------------
-// isBacklogHygieneStatus tests
-// ----------------------------------------------------------
-console.log("Testing isBacklogHygieneStatus...");
+  test("returns null when today is before any sprint", () => {
+    const before = [{ id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 }];
+    assert.equal(findCurrentSprint(before, "2026-04-25"), null);
+  });
 
-assert.strictEqual(isBacklogHygieneStatus(undefined), true, "empty status is eligible");
-assert.strictEqual(isBacklogHygieneStatus("Needs Refinement"), true, "Needs Refinement is eligible");
-assert.strictEqual(isBacklogHygieneStatus("🛠️ Needs Refinement"), true, "emoji-prefixed Needs Refinement is eligible");
-assert.strictEqual(isBacklogHygieneStatus("TODO"), true, "TODO is eligible");
-assert.strictEqual(isBacklogHygieneStatus("🆕 ToDo"), true, "emoji-prefixed ToDo is eligible");
-assert.strictEqual(isBacklogHygieneStatus("In Progress"), false, "In Progress is not eligible");
-assert.strictEqual(isBacklogHygieneStatus("In Review"), false, "In Review is not eligible");
+  test("returns null when no sprint range contains today", () => {
+    const after = [{ id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 }];
+    assert.equal(findCurrentSprint(after, "2026-04-25"), null);
+  });
+});
 
-console.log("  isBacklogHygieneStatus: all passed");
+describe("isBacklogHygieneStatus", () => {
+  test("empty status is eligible", () => assert.equal(isBacklogHygieneStatus(undefined), true));
+  test("Needs Refinement is eligible", () => assert.equal(isBacklogHygieneStatus("Needs Refinement"), true));
+  test("emoji-prefixed Needs Refinement is eligible", () => assert.equal(isBacklogHygieneStatus("🛠️ Needs Refinement"), true));
+  test("TODO is eligible", () => assert.equal(isBacklogHygieneStatus("TODO"), true));
+  test("emoji-prefixed ToDo is eligible", () => assert.equal(isBacklogHygieneStatus("🆕 ToDo"), true));
+  test("In Progress is not eligible", () => assert.equal(isBacklogHygieneStatus("In Progress"), false));
+  test("In Review is not eligible", () => assert.equal(isBacklogHygieneStatus("In Review"), false));
+});
 
-// ----------------------------------------------------------
-// isTerminalStatus tests
-// ----------------------------------------------------------
-console.log("Testing isTerminalStatus...");
+describe("isTerminalStatus", () => {
+  test("Done is terminal", () => assert.equal(isTerminalStatus("Done"), true));
+  test("emoji-prefixed Done is terminal", () => assert.equal(isTerminalStatus("🍺 Done"), true));
+  test("Closed is terminal", () => assert.equal(isTerminalStatus("Closed"), true));
+  test("emoji-prefixed Closed is terminal", () => assert.equal(isTerminalStatus("🔒Closed"), true));
+  test("In Progress is not terminal", () => assert.equal(isTerminalStatus("In Progress"), false));
+  test("Review is not terminal", () => assert.equal(isTerminalStatus("Review"), false));
+});
 
-assert.strictEqual(isTerminalStatus("Done"), true, "Done is terminal");
-assert.strictEqual(isTerminalStatus("🍺 Done"), true, "emoji-prefixed Done is terminal");
-assert.strictEqual(isTerminalStatus("Closed"), true, "Closed is terminal");
-assert.strictEqual(isTerminalStatus("🔒Closed"), true, "emoji-prefixed Closed is terminal");
-assert.strictEqual(isTerminalStatus("In Progress"), false, "In Progress is not terminal");
-assert.strictEqual(isTerminalStatus("Review"), false, "Review is not terminal");
+describe("isNeedsRefinementStatus", () => {
+  test("Needs Refinement is matched", () => assert.equal(isNeedsRefinementStatus("Needs Refinement"), true));
+  test("emoji-prefixed Needs Refinement is matched", () => assert.equal(isNeedsRefinementStatus("🛠️ Needs Refinement"), true));
+  test("Next-UP is not Needs Refinement", () => assert.equal(isNeedsRefinementStatus("Next-UP"), false));
+  test("emoji-prefixed Next-UP is not Needs Refinement", () => assert.equal(isNeedsRefinementStatus("📋 Next-UP"), false));
+});
 
-console.log("  isTerminalStatus: all passed");
+describe("assertAllowedProjectNumber", () => {
+  test("matching project number should be allowed", () => {
+    assert.doesNotThrow(() => assertAllowedProjectNumber(DEFAULT_ALLOWED_PROJECT_NUMBER, DEFAULT_ALLOWED_PROJECT_NUMBER));
+  });
+  test("missing allowed project number should disable the guard", () => {
+    assert.doesNotThrow(() => assertAllowedProjectNumber(123, undefined));
+  });
+  test("mismatched project number should be rejected", () => {
+    assert.throws(() => assertAllowedProjectNumber(123, DEFAULT_ALLOWED_PROJECT_NUMBER), /unexpected project/);
+  });
+});
 
-// ----------------------------------------------------------
-// isNeedsRefinementStatus tests
-// ----------------------------------------------------------
-console.log("Testing isNeedsRefinementStatus...");
-
-assert.strictEqual(isNeedsRefinementStatus("Needs Refinement"), true, "Needs Refinement is matched");
-assert.strictEqual(isNeedsRefinementStatus("🛠️ Needs Refinement"), true, "emoji-prefixed Needs Refinement is matched");
-assert.strictEqual(isNeedsRefinementStatus("Next-UP"), false, "Next-UP is not Needs Refinement");
-assert.strictEqual(isNeedsRefinementStatus("📋 Next-UP"), false, "emoji-prefixed Next-UP is not Needs Refinement");
-
-console.log("  isNeedsRefinementStatus: all passed");
-
-// ----------------------------------------------------------
-// assertAllowedProjectNumber tests
-// ----------------------------------------------------------
-console.log("Testing assertAllowedProjectNumber...");
-
-assert.doesNotThrow(
-  () => assertAllowedProjectNumber(DEFAULT_ALLOWED_PROJECT_NUMBER, DEFAULT_ALLOWED_PROJECT_NUMBER),
-  "matching project number should be allowed",
-);
-assert.doesNotThrow(
-  () => assertAllowedProjectNumber(123, undefined),
-  "missing allowed project number should disable the guard",
-);
-assert.throws(
-  () => assertAllowedProjectNumber(123, DEFAULT_ALLOWED_PROJECT_NUMBER),
-  /unexpected project/,
-  "mismatched project number should be rejected",
-);
-
-console.log("  assertAllowedProjectNumber: all passed");
-
-// ----------------------------------------------------------
-// projectFieldQueryToken tests
-// ----------------------------------------------------------
-console.log("Testing projectFieldQueryToken...");
-
-assert.strictEqual(
-  projectFieldQueryToken("Story Points (Number)"),
-  "story-points-(number)",
-  "field display name should become the Projects search token",
-);
-assert.strictEqual(
-  projectFieldQueryToken("Story Points"),
-  "story-points",
-  "fallback field name should become the Projects search token",
-);
-
-console.log("  projectFieldQueryToken: all passed");
-
-console.log("\nAll sprint-hygiene tests passed.");
+describe("projectFieldQueryToken", () => {
+  test("field display name should become the Projects search token", () => {
+    assert.equal(projectFieldQueryToken("Story Points (Number)"), "story-points-(number)");
+  });
+  test("fallback field name should become the Projects search token", () => {
+    assert.equal(projectFieldQueryToken("Story Points"), "story-points");
+  });
+});

--- a/.github/scripts/sprint-hygiene.test.js
+++ b/.github/scripts/sprint-hygiene.test.js
@@ -8,76 +8,83 @@ import {
   isBacklogHygieneStatus,
   isNeedsRefinementStatus,
   isTerminalStatus,
+  parseIteration,
   projectFieldQueryToken,
 } from "./sprint-hygiene.js";
 
+// The helpers work on Date-based iterations; parse ISO fixtures the same way
+// the production code does at the GraphQL boundary. `d` builds a UTC-midnight
+// Date from an ISO date string, matching how `today` is compared.
+const iters = (...rows) => rows.map(parseIteration);
+const d = (isoDate) => new Date(isoDate);
+
 describe("findNextSprint", () => {
   test("returns the next sprint after the current sprint", () => {
-    const iterations = [
+    const iterations = iters(
       { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
       { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
       { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
-    ];
-    assert.equal(findNextSprint(iterations, "2026-04-25").id, "s3");
+    );
+    assert.equal(findNextSprint(iterations, d("2026-04-25")).id, "s3");
   });
 
   test("returns the sprint after today's starting sprint", () => {
-    const iterations = [
+    const iterations = iters(
       { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
       { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
       { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
-    ];
-    assert.equal(findNextSprint(iterations, "2026-04-21").id, "s3");
+    );
+    assert.equal(findNextSprint(iterations, d("2026-04-21")).id, "s3");
   });
 
   test("falls back to nearest upcoming sprint when today is before all iterations", () => {
-    const iterations = [
+    const iterations = iters(
       { id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 },
       { id: "s2", title: "Sprint 2", startDate: "2026-05-15", duration: 14 },
-    ];
-    assert.equal(findNextSprint(iterations, "2026-04-25").id, "s1");
+    );
+    assert.equal(findNextSprint(iterations, d("2026-04-25")).id, "s1");
   });
 
   test("returns null when no upcoming sprint exists", () => {
-    const iterations = [
+    const iterations = iters(
       { id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 },
       { id: "s2", title: "Sprint 2", startDate: "2026-03-15", duration: 14 },
-    ];
-    assert.equal(findNextSprint(iterations, "2026-04-25"), null);
+    );
+    assert.equal(findNextSprint(iterations, d("2026-04-25")), null);
   });
 });
 
 describe("findCurrentSprint", () => {
-  const iterations = [
+  const iterations = iters(
     { id: "s1", title: "Sprint 1", startDate: "2026-04-07", duration: 14 },
     { id: "s2", title: "Sprint 2", startDate: "2026-04-21", duration: 14 },
     { id: "s3", title: "Sprint 3", startDate: "2026-05-05", duration: 14 },
-  ];
+  );
 
   test("picks the sprint whose range contains today", () => {
-    assert.equal(findCurrentSprint(iterations, "2026-04-25").id, "s2");
+    assert.equal(findCurrentSprint(iterations, d("2026-04-25")).id, "s2");
   });
 
   test("start date is inclusive", () => {
-    assert.equal(findCurrentSprint(iterations, "2026-04-21").id, "s2");
+    assert.equal(findCurrentSprint(iterations, d("2026-04-21")).id, "s2");
   });
 
   test("last day of the range still belongs to the sprint", () => {
-    assert.equal(findCurrentSprint(iterations, "2026-05-04").id, "s2");
+    assert.equal(findCurrentSprint(iterations, d("2026-05-04")).id, "s2");
   });
 
   test("end date is exclusive - the next sprint's start day rolls over", () => {
-    assert.equal(findCurrentSprint(iterations, "2026-05-05").id, "s3");
+    assert.equal(findCurrentSprint(iterations, d("2026-05-05")).id, "s3");
   });
 
   test("returns null when today is before any sprint", () => {
-    const before = [{ id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 }];
-    assert.equal(findCurrentSprint(before, "2026-04-25"), null);
+    const before = iters({ id: "s1", title: "Sprint 1", startDate: "2026-05-01", duration: 14 });
+    assert.equal(findCurrentSprint(before, d("2026-04-25")), null);
   });
 
   test("returns null when no sprint range contains today", () => {
-    const after = [{ id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 }];
-    assert.equal(findCurrentSprint(after, "2026-04-25"), null);
+    const after = iters({ id: "s1", title: "Sprint 1", startDate: "2026-03-01", duration: 14 });
+    assert.equal(findCurrentSprint(after, d("2026-04-25")), null);
   });
 });
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist/
 output/
 /.project
 node_modules
+.github/scripts/plan.json


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Sprint hygiene was pushing active work **one sprint too far into the future**. 

##### Issue

Sprint Hygiene pushed expired active work (In Progress / Next-UP / In Review) one sprint too far, because the engine computed a single targetSprint  (the next sprint via findNextSprint) and reused it for every rule.                                                                                          
                                                                                                
##### Fix:

Made the destination a per-rule decision 
- added findCurrentSprint and resolved both currentSprint and nextSprint, 
- "Roll expired sprint items forward" now targets the current sprint while "Move refinement work to planning sprint" keeps targeting the next sprint.     

#### Which issue(s) this PR fixes

Fixes #1174

#### Testing

##### How to test the changes

```bash
# Unit tests (pure helpers, incl. new findCurrentSprint cases)
node .github/scripts/sprint-hygiene.test.js

# Local dry-run against project #10 (read-only; needs GH_TOKEN/GITHUB_TOKEN with project scopes)
node .github/scripts/sprint-hygiene.local.js --plan plan.json

# Apply for real
node .github/scripts/sprint-hygiene.local.js --apply
```

##### Verification

Verified end-to-end against live project #10:

- Unit tests pass, including new `findCurrentSprint` coverage
- Live run: moving #1174 into a past sprint (Sprint 65), the apply run rolled it forward to **Sprint 66 (current)** and not Sprint 67 (next) — and posted the hygiene comment. 
