### PR TITLE
fix: add sprint-hygiene/ignore and wire it in here

### DIFF
--- a/.github/scripts/sprint-hygiene.js
+++ b/.github/scripts/sprint-hygiene.js
@@ -77,6 +77,7 @@ export function findCurrentSprint(iterations, today) {
 
 const EXCLUDED_STATUSES = ["done", "closed"];
 const SPRINT_ASSIGN_STATUSES = ["needs refinement", "todo"];
+const IGNORE_LABEL = "sprint-hygiene/ignore";
 const STATUS_FIELD_NAME = "Status";
 const SPRINT_FIELD_NAME = "Sprint";
 const STORY_POINTS_FIELD_NAMES = ["Story Points (Number)", "Story Points"];
@@ -549,7 +550,7 @@ function plannedAction(rule, item) {
     };
 }
 
-function buildRules(config, sprints) {
+export function buildRules(config, sprints) {
     // Each rule decides where it moves items. Active work rolling off an expired
     // sprint belongs in the *current* sprint so it stays on the active board,
     // while refinement work is planned ahead in the *next* sprint.
@@ -569,11 +570,14 @@ function buildRules(config, sprints) {
         option: config.needsRefinementOption,
     });
 
+    // Items carrying this label are opted out of all sprint hygiene rules.
+    const ignoreLabelFilter = `-label:${quoteProjectFilterValue(IGNORE_LABEL)}`;
+
     return [
         {
             name: "Roll expired sprint items forward",
             // Project filter: open issues with any sprint before the current sprint.
-            filter: "is:open -is:draft sprint:<@current",
+            filter: `is:open -is:draft sprint:<@current ${ignoreLabelFilter}`,
             // Item checks: keep all non-terminal items, regardless of active status.
             // This includes ToDo, Next-UP, In Progress, Review, and QA work whose
             // sprint is already in the past.
@@ -598,6 +602,7 @@ function buildRules(config, sprints) {
                 "sprint:>=@current",
                 `no:${projectFieldQueryToken(config.storyPointsField?.name ?? STORY_POINTS_FIELD_NAMES[0])}`,
                 `-status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
+                ignoreLabelFilter,
             ].join(" "),
             skipReason: config.storyPointsField ? null : "no story points field found on project",
             // Item checks: only unsized backlog/refinement candidates. This avoids
@@ -627,6 +632,7 @@ function buildRules(config, sprints) {
                 "-is:draft",
                 "sprint:@current",
                 `status:${quoteProjectFilterValue(config.needsRefinementOption.name)}`,
+                ignoreLabelFilter,
             ].join(" "),
             // Item checks: keep the status check as a defensive fallback in case
             // Project search semantics change.

--- a/.github/scripts/sprint-hygiene.test.js
+++ b/.github/scripts/sprint-hygiene.test.js
@@ -2,6 +2,7 @@ import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 import {
   assertAllowedProjectNumber,
+  buildRules,
   DEFAULT_ALLOWED_PROJECT_NUMBER,
   findCurrentSprint,
   findNextSprint,
@@ -133,4 +134,34 @@ describe("projectFieldQueryToken", () => {
   test("fallback field name should become the Projects search token", () => {
     assert.equal(projectFieldQueryToken("Story Points"), "story-points");
   });
+});
+
+describe("buildRules ignore label", () => {
+  const config = {
+    projectId: "PROJECT_ID",
+    sprintField: { id: "SPRINT_FIELD" },
+    statusField: { id: "STATUS_FIELD" },
+    needsRefinementOption: { id: "OPTION_ID", name: "🛠️ Needs Refinement" },
+    storyPointsField: { name: "Story Points (Number)" },
+  };
+  const sprints = {
+    current: { id: "s1", title: "Sprint 1" },
+    next: { id: "s2", title: "Sprint 2" },
+  };
+  const rules = buildRules(config, sprints);
+
+  test("builds all three hygiene rules", () => {
+    assert.equal(rules.length, 3);
+  });
+
+  // Every rule must opt out issues carrying the ignore label, quoted because
+  // the label contains a slash.
+  for (const rule of rules) {
+    test(`"${rule.name}" excludes the sprint-hygiene/ignore label`, () => {
+      assert.ok(
+        rule.filter.includes(`-label:"sprint-hygiene/ignore"`),
+        `filter: ${rule.filter}`,
+      );
+    });
+  }
 });


### PR DESCRIPTION
This PR adds a blacklist label `sprint-hygiene/ignore` to our script.
The change is needed to stop moving our "Sprint Responsible" issues via the sprint-hygiene script.

https://github.com/open-component-model/ocm-project/issues/1166#issuecomment-4966391148

I have already updated all existing issues and added that label