### PR TITLE
chore: replace kind/task and kind/epic labels by issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -2,7 +2,7 @@
 name: Epic Template
 about: Template for a new Epic
 title: 'EPIC: '
-labels: kind/epic
+type: Epic
 assignees: ''
 
 ---
@@ -15,6 +15,7 @@ As a DevOps admin, I want to ...
 
 **Scope**
 List all deliverables that are part of this epic. The Epic is considered DONE if all of the below mentioned deliverables are available.
+
 - [ ] Function 1
 - [ ] Function 2
 - [ ] Tests
@@ -24,4 +25,3 @@ List all deliverables that are part of this epic. The Epic is considered DONE if
 
 **Out of Scope**
 List features or implementation strategies that shouldn't be considered in this iteration.
-

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -2,16 +2,18 @@
 name: Task (Spike) / Backlog Item
 about: Create a Spike Task / Backlog Item to be worked on
 title: ''
-labels: kind/task kind/spike
+type: Spike
 assignees: ''
 
 ---
 
 **Description**
+What is the goal of this spike?
 
 ### Timebox: 1 day(s)
 
 **Done Criteria**
+
 - [ ] Estimation of impact on existing code incl. tests
 - [ ] Estimation of impact on Enduser Documentation updated (if applicable)
 - [ ] Estimation of impact on Internal technical Documentation created/updated (if applicable)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Task / Backlog Item
 about: Create a Task / Backlog Item to be worked on
 title: ''
-labels: kind/task
+type: Task
 assignees: ''
 
 ---
@@ -10,6 +10,7 @@ assignees: ''
 **Description**
 
 **Done Criteria**
+
 - [ ] ...
 - [ ] Code has been reviewed by other team members
 - [ ] Analysis of existing tests (Unit and Integration)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

With https://github.com/open-component-model/ocm-project/issues/1216, all issues should use the type attribute instead of using kind labels. This PR adjusts the issue templates to use the issue type instead

#### Changes

- Adjusts issue templates to use the type field instead of labels

#### Which issue(s) this PR is related to

Related to https://github.com/open-component-model/ocm-project/issues/1216